### PR TITLE
update to use dispose instead of deprecated config.unobserve

### DIFF
--- a/lib/linter-pep257.coffee
+++ b/lib/linter-pep257.coffee
@@ -16,12 +16,14 @@ class Linterpep257 extends Linter
 
   constructor: (editor)->
     super(editor)
-    atom.config.observe 'linter-pep257.execPath', => @updateCommand()
-    atom.config.observe 'linter-pep257.ignoreCodes', => @updateCommand()
+    @execPathListener = atom.config.observe 'linter-pep257.execPath',
+      => @updateCommand()
+    @ignoreCodesListener = atom.config.observe 'linter-pep257.ignoreCodes',
+      => @updateCommand()
 
   destroy: ->
-    atom.config.unobserve 'linter-pep257.execPath'
-    atom.config.unobserve 'linter-pep257.ignoreCodes'
+    @execPathListener.dispose()
+    @ignoreCodesListener.dispose()
 
   updateCommand: ->
     cmd = [atom.config.get 'linter-pep257.execPath']


### PR DESCRIPTION
Deprecation Cop warns "Config::unobserve no longer does anything. Call .dispose() on the object returned by Config::observe instead." Code updated to current API.