### PR TITLE
fix / improve matching messages

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -36,7 +36,8 @@ module.exports =
     # parse lint output
     output = output.replace(/:[\r\n]\s+/mg, " | ") # combine multiline output
     messages = helpers.parse(output,
-                             "^(?<file>.+):(?<line>\\d+)\\s+(?<message>.+)")
+                             "^(?<file>.+):(?<line>\\d+).+ \\| (?<message>.+)",
+                             {flags: 'gm'})
     messages.forEach (msg) ->
       msg.type = "Info"
     return messages


### PR DESCRIPTION
Currently the regex is not using the multiline option. Therefore the `^` results in only matching the first message. Passing the flag `m` allows to match `^` at every line and therefore match all messages.

Additionally the string after the line number and before the newline (replaced by a pipe) is not relevant for the message. It only contains information about the scope but since the message will be shown at a specific location in the file it is sufficient to show only the part starting with `D00x something is wrong` (after the newline / pipe).