### PR TITLE
Update to match name change in underlying package from pep257 to pydocstyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env: ATOM_CHANNEL=beta
 
 install:
-  - pip install pep257
+  - pip install pydocstyle
 
 # Generic setup follows
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'

--- a/README.md
+++ b/README.md
@@ -1,45 +1,45 @@
-# linter-pep257
+# linter-pydocstyle
 
 A [Linter][linter] plugin to lint Python docstrings according to the semantics
-and conventions spec'd in [pep257][spec].
+and conventions spec'd in [PEP 257][spec].
 
 In use side-by-side with the flake8 linter:
 
-![Screenshot of pep257 feedback](https://cloud.githubusercontent.com/assets/154988/9623112/5ee0bf1e-510a-11e5-815b-a339fa85ebac.png)
+![Screenshot of pydocstyle feedback](https://cloud.githubusercontent.com/assets/154988/9623112/5ee0bf1e-510a-11e5-815b-a339fa85ebac.png)
 
 ## Installation
 
 1.  [Install Linter][install linter].
 
-2.  Install python package [pep257][], run:
+2.  Install python package [pydocstyle][], run:
 
     ```ShellSession
-    pip install pep257
+    pip install pydocstyle
     ```
 
 3.  Install package, run:
 
     ```ShellSession
-    apm install linter-pep257
+    apm install linter-pydocstyle
     ```
 
 ## Configuration
 
-| Setting                         | Values                                                           |
-| ------------------------------- | ---------------------------------------------------------------- |
-| Error codes to ignore           | Example: `D100,D101` - [all available error codes][pep257 codes] |
-| Path to executable `pep257` cmd | Default: pep257                                                  |
+| Setting                             | Values                                                               |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| Error codes to ignore               | Example: `D100,D101` - [all available error codes][pydocstyle codes] |
+| Path to executable `pydocstyle` cmd | Default: pydocstyle                                                  |
 
 If using python version management, like [pyenv][], the path configuration will
-need to be set.  For pyenv, the path for pep257 is discoverable by executing:
+need to be set.  For pyenv, the path for pydocstyle is discoverable by executing:
 
 ```ShellSession
-pyenv which pep257
+pyenv which pydocstyle
 ```
 
 [linter]: https://github.com/atom-community/linter
 [install linter]: https://github.com/atom-community/linter#installation
-[pep257]: https://pypi.python.org/pypi/pep257
-[pep257 codes]: http://pep257.readthedocs.org/en/latest/error_codes.html
+[pydocstyle]: https://pypi.python.org/pypi/pydocstyle
+[pydocstyle codes]: http://pydocstyle.readthedocs.org/en/latest/error_codes.html
 [pyenv]: https://github.com/yyuu/pyenv
 [spec]: https://www.python.org/dev/peps/pep-0257/

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,13 +6,13 @@ module.exports =
     executablePath:
       title: 'Executable Path'
       type: 'string'
-      default: 'pep257'
-      description: "Path to executable pep257 cmd."
+      default: 'pydocstyle'
+      description: "Path to executable pydocstyle cmd."
     ignoreCodes:
       type: 'string'
       default: ''
       description: ('Comma separated list of error codes to ignore. ' +
-        'Available codes: https://pypi.python.org/pypi/pep257#error-codes')
+        'Available codes: https://pypi.python.org/pypi/pydocstyle#error-codes')
     ignoreFiles:
       type: 'string'
       default: ''
@@ -21,13 +21,13 @@ module.exports =
   activate: ->
     require('atom-package-deps').install('linter-pep257')
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.config.observe 'linter-pep257.executablePath',
+    @subscriptions.add atom.config.observe 'linter-pydocstyle.executablePath',
       (executablePath) =>
         @executablePath = executablePath
-    @subscriptions.add atom.config.observe 'linter-pep257.ignoreCodes',
+    @subscriptions.add atom.config.observe 'linter-pydocstyle.ignoreCodes',
       (ignoreCodes) =>
         @ignoreCodes = ignoreCodes
-    @subscriptions.add atom.config.observe 'linter-pep257.ignoreFiles',
+    @subscriptions.add atom.config.observe 'linter-pydocstyle.ignoreFiles',
       (ignoreFiles) =>
         @ignoreFiles = ignoreFiles
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "linter-pep257",
+  "name": "linter-pydocstyle",
   "main": "./lib/init",
   "version": "0.4.0",
   "description": "Lint Python docstrings on the fly.",
-  "repository": "https://github.com/AtomLinter/linter-pep257",
+  "repository": "https://github.com/AtomLinter/linter-pydocstyle",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"

--- a/spec/linter-pydocstyle-spec.coffee
+++ b/spec/linter-pydocstyle-spec.coffee
@@ -1,4 +1,4 @@
-LinterPEP257 = require '../lib/init'
+LinterPydocstyle = require '../lib/init'
 path = require 'path'
 
 goodPath = path.join(__dirname, 'fixtures', 'good.py')
@@ -9,15 +9,15 @@ describe "starts everything up", ->
   lint = require('../lib/init').provideLinter().lint
   beforeEach ->
     waitsForPromise ->
-      atom.packages.activatePackage('linter-pep257')
+      atom.packages.activatePackage('linter-pydocstyle')
     waitsForPromise ->
       atom.packages.activatePackage("language-python")
 
   it 'should be in the package list', ->
-    expect(atom.packages.isPackageLoaded('linter-pep257')).toBe true
+    expect(atom.packages.isPackageLoaded('linter-pydocstyle')).toBe true
 
   it 'should have activated the package', ->
-    expect(atom.packages.isPackageActive('linter-pep257')).toBe true
+    expect(atom.packages.isPackageActive('linter-pydocstyle')).toBe true
 
   describe "reads good.py and", ->
     editor = null


### PR DESCRIPTION
pep257 linter tool changed its name to pydocstyle per Guido's request: https://github.com/PyCQA/pydocstyle/issues/172

Fix #31